### PR TITLE
WindowManager: Always use hardware composition

### DIFF
--- a/core/java/android/view/Window.java
+++ b/core/java/android/view/Window.java
@@ -735,8 +735,8 @@ public abstract class Window {
             boolean hardwareAccelerated) {
         mAppToken = appToken;
         mAppName = appName;
-        mHardwareAccelerated = hardwareAccelerated
-                || SystemProperties.getBoolean(PROPERTY_HARDWARE_UI, false);
+        mHardwareAccelerated = true;
+
         if (wm == null) {
             wm = (WindowManager)mContext.getSystemService(Context.WINDOW_SERVICE);
         }


### PR DESCRIPTION
The persist.sys.ui.hw prop is exposed to userspace via developer options,
but we can't allow the user to disable hardware composition due to resulting
graphical artifacts and glitches.

Always enable hardware composition in order to prevent the user from
bugging out the system.