### PR TITLE
Disable app verification and enable non market apps installation

### DIFF
--- a/packages/SettingsProvider/res/values/defaults.xml
+++ b/packages/SettingsProvider/res/values/defaults.xml
@@ -39,7 +39,7 @@
     <bool name="def_bluetooth_on">false</bool>
     <bool name="def_wifi_display_on">false</bool>
     <bool name="def_install_non_market_apps">true</bool>
-    <bool name="def_package_verifier_enable">true</bool>
+    <bool name="def_package_verifier_enable">false</bool>
     <!-- Comma-separated list of location providers.
          Network location is off by default because it requires
          user opt-in via Setup Wizard or Settings.


### PR DESCRIPTION
app verification can also slow down Titanium backupe restore
operations

Change-Id: I0ba28ad07a7175d4e18e1d8e1808616e81317948