### PR TITLE
Telephony: Stop using rssnr, it falsly shows wrong signal bars

### DIFF
--- a/telephony/java/android/telephony/SignalStrength.java
+++ b/telephony/java/android/telephony/SignalStrength.java
@@ -872,6 +872,9 @@ public class SignalStrength implements Parcelable {
         if (DBG) log("getLTELevel - rsrp:" + mLteRsrp + " snr:" + mLteRssnr + " rsrpIconLevel:"
                 + rsrpIconLevel + " snrIconLevel:" + snrIconLevel
                 + " lteRsrpBoost:" + mLteRsrpBoost);
+	
+	/* Ignore RSSNR for now */
+	if(rsrpIconLevel != -1) return rsrpIconLevel;
 
         /* Choose a measurement type to use for notification */
         if (snrIconLevel != -1 && rsrpIconLevel != -1) {


### PR DESCRIPTION
The reason is that the modem reports a bad signal-noise ratio (RSSNR) to the system RIL which causes a improper read of the signal strength on the statusbar.

The REAL fix is to is to ignore the RSSNR value and base the signal result on dBm (actual signal level), when the noise value is very high which probably is what Xiaomi did to MIUI. This solves all signal issues for Oreo ROMs and Nougat ROMs. 

Change-Id: Iaa54351bfcb8b7abe61a9cc6efef567a999e8198