### PR TITLE
base: Make vendor mismatch message optional

### DIFF
--- a/core/res/res/values/custom_config.xml
+++ b/core/res/res/values/custom_config.xml
@@ -331,4 +331,7 @@
       <item>com.Slack</item>
 	</string-array>
 
+    <!-- Whether or not we should show vendor mismatch message -->
+    <bool name="config_show_vendor_mismatch_message">true</bool>
+
 </resources>

--- a/core/res/res/values/custom_symbols.xml
+++ b/core/res/res/values/custom_symbols.xml
@@ -344,4 +344,7 @@
     <!-- sensor block -->
     <java-symbol type="array" name="config_blockPackagesSensorDrain" />
 
+    <!-- Show Vendor mismatch warning -->
+    <java-symbol type="bool" name="config_show_vendor_mismatch_message" />
+
 </resources>

--- a/services/core/java/com/android/server/am/ActivityManagerService.java
+++ b/services/core/java/com/android/server/am/ActivityManagerService.java
@@ -2134,7 +2134,13 @@ public class ActivityManagerService extends IActivityManager.Stub
                 }
             } break;
             case SHOW_FINGERPRINT_ERROR_UI_MSG: {
-                if (mShowDialogs) {
+
+                boolean mShowVendorMismatch = Resources.getSystem().getBoolean(
+                        R.bool.config_show_vendor_mismatch_message);
+                if (mShowDialogs && mShowVendorMismatch) {
+                    String buildfingerprint = SystemProperties.get("ro.build.fingerprint");
+                    String[] splitfingerprint = buildfingerprint.split("/");
+                    String vendorid = splitfingerprint[3];
                     AlertDialog d = new BaseErrorDialog(mUiContext);
                     d.getWindow().setType(WindowManager.LayoutParams.TYPE_SYSTEM_ERROR);
                     d.setCancelable(false);


### PR DESCRIPTION
**To Fix vendor mismatch warning on boot with custom kernels**

Use this flag in the device tree to Fix vendor mismatch warning

overlay/frameworks/base/core/res/res/values/config.xml

```
    <!-- Whether or not we should show vendor mismatch message -->
    <bool name="config_show_vendor_mismatch_message">false</bool>
```